### PR TITLE
CFE-3427/master: Changed references from bundle server access_rules to my_access_rules

### DIFF
--- a/examples/example-snippets/all_hosts_the_same.cf
+++ b/examples/example-snippets/all_hosts_the_same.cf
@@ -46,7 +46,7 @@ body server control
 }
 #########################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
   access:
       # myhost.domain.tld makes this file available to 10.20.30*

--- a/examples/example-snippets/client-server_example.cf
+++ b/examples/example-snippets/client-server_example.cf
@@ -88,7 +88,7 @@ body server control
 }
 #########################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
   access:
       "/home/mark/LapTop"

--- a/examples/example-snippets/copy_and_flatten_directory.cf
+++ b/examples/example-snippets/copy_and_flatten_directory.cf
@@ -86,7 +86,7 @@ body server control
 }
 #########################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
   access:
       "/home/mark/LapTop"

--- a/examples/example-snippets/promise-patterns/example_updating_from_central_hub.markdown
+++ b/examples/example-snippets/promise-patterns/example_updating_from_central_hub.markdown
@@ -54,10 +54,10 @@ trustkeysfrom         => { "127.0.0.1" , "10.20.30.0/24" };
 
 Since we assume that all hosts are on network 10.20.30.* they will be granted access. In the default policy this is set to `$(sys.policy_hub)/16`, i.e. all hosts in the same class B network as the hub will gain access. You will need to modify the access control list in `body server control` if you have clients outside of the policy server's class B network.
 
-Granting access to files and folders needs to be done in `bundle server access_rules()`:
+Granting access to files and folders needs to be done using `access` type promises in a `server` bundle, for example, `bundle server my_access_rules()`:
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 

--- a/examples/example-snippets/updating_from_a_central_hub.cf
+++ b/examples/example-snippets/updating_from_a_central_hub.cf
@@ -27,7 +27,7 @@ body server control
 }
 #######################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
   access:
     10_20_30_123::

--- a/examples/example-snippets/variation_in_hosts.cf
+++ b/examples/example-snippets/variation_in_hosts.cf
@@ -57,7 +57,7 @@ body server control
 }
 #########################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
   access:
       # myhost.domain.tld makes this file available to 10.20.30*

--- a/examples/tutorials/distribute-files-from-a-central-location.markdown
+++ b/examples/tutorials/distribute-files-from-a-central-location.markdown
@@ -66,16 +66,20 @@ These common variables can be referenced from the rest of the policy by using th
 
 Access must be granted before files can be copied. The right to access a file
 is provided by `cf-serverd`, the server component of CFEngine. Enter access information using the `access`
-promise type in the `bundle server access_rules` section. This section is located in
-`controls/cf_serverd.cf` in the policy framework.
+promise type in a `server` bundle. The default access rules defined by the MPF (Masterfiles Policy Framework) can be found in
+`controls/cf_serverd.cf`.
 
-For our example, add the following information to `controls/cf_serverd.cf`:
+There is no need to modify the vendored policy, instead define your own server bundle. For our example, add the following to `services/main.cf`:
 
-```
-"$(def.dir_patch_store)"
-  handle => "server_access_grant_locations_files_patch_store_for_hosts",
-  admit => { ".*$(def.domain)", @(def.acl) },
-  comment => "Hosts need to download patch files from the central location";
+```cf3
+bundle server my_access_rules
+{
+  access:
+    "$(def.dir_patch_store)"
+      handle => "server_access_grant_locations_files_patch_store_for_hosts",
+      admit => { ".*$(def.domain)", @(def.acl) },
+      comment => "Hosts need to download patch files from the central location";
+}
 ```
 
 ### Create a custom library for reusable synchronization policy

--- a/guide/introduction/networking.markdown
+++ b/guide/introduction/networking.markdown
@@ -108,7 +108,7 @@ Once you have arranged for the right to connect to the server, you must decide
 which hosts will have access to which files. This is done with `access` promises.
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 {
   access:
     "/path/file"

--- a/guide/special-topics/distributed-scheduling.markdown
+++ b/guide/special-topics/distributed-scheduling.markdown
@@ -142,7 +142,7 @@ this has a small network cost, and requires some extra configuration on the
 server side to grant access to this context information:
 
 ```cf3
-bundle server access_rules
+bundle server my_access_rules
 {
 access:
 
@@ -311,7 +311,7 @@ allowusers            => { "mark" };
 
 #########################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 

--- a/guide/special-topics/file-integrity-monitoring.markdown.breaks_build
+++ b/guide/special-topics/file-integrity-monitoring.markdown.breaks_build
@@ -296,7 +296,8 @@ The copy rule attempts to copy the database to some file in a safekeeping direct
 
 Finally, in order to make this copy, you must, of course, grant access to the database in by granting access to the database in a bundle of server promises:
 
-bundle server access_rules()
+```cf3
+bundle server my_access_rules()
 {
 vars:
 
@@ -317,6 +318,8 @@ access:
      handle => "grant_hash_tables",
     admit   => { @(acl) },
     maproot => { @(acl) };
+}
+```
 
 Let us now consider what happens if an attacker changes a file an edits the checksum database. Each of the four hosts that has been designated a neighbour will attempt to update their own copy of the database. If the database has been tampered with, they will detect a change in the hashes of the remote copy versus the original. The file will therefore be copied.
 

--- a/guide/special-topics/modularity.markdown
+++ b/guide/special-topics/modularity.markdown
@@ -635,7 +635,7 @@ promise_repaired => { "did_task_one","did_task_two", "did_task_three" };
 persist_time => "10";
 }
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -713,7 +713,7 @@ reports:
 
 #######################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -810,7 +810,7 @@ commands:
 
 #######################################################
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -957,7 +957,7 @@ files:
 ############################################################
 
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -1165,7 +1165,7 @@ reports:
 ############################################################
 
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -1438,7 +1438,7 @@ insert_lines:
 ############################################################
 
 
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 

--- a/guide/special-topics/role-based-access-control.markdown.breaks_build
+++ b/guide/special-topics/role-based-access-control.markdown.breaks_build
@@ -337,10 +337,10 @@ running the agent with a defined class, e.g.
 host# cf-agent -D extraordinary
 ```
 
-However, it is also possible to grant access to these parts of a CFEngine policy that are normally switched off by usingcf-serverdto mediate privilege to execute the agent with this class active. For example, setting:
+However, it is also possible to grant access to these parts of a CFEngine policy that are normally switched off by using cf-serverd to mediate privilege to execute the agent with this class active. For example, setting:
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 {
 roles:
 

--- a/reference/components/cf-serverd.markdown
+++ b/reference/components/cf-serverd.markdown
@@ -341,48 +341,50 @@ The sequence of events is this:
 
     call_collect_interval => "5";
 
-The full configuration would look something like this
+The full configuration to enable client initiated reporting would look something like this:
 
 ```cf3
-        #########################################################
-        # Server config
-        #########################################################
+#########################################################
+# Server config
+#########################################################
 
-        body server control
-        {
-        allowconnects         => { "10.10.10.0/24" , "::1" };
-        allowallconnects      => { "10.10.10.0/24" , "::1" };
-        trustkeysfrom         => { "10.10.10.0/24" , "::1" };
+body server control
+{
+  allowconnects         => { "10.10.10.0/24" , "::1" };
+  allowallconnects      => { "10.10.10.0/24" , "::1" };
+  trustkeysfrom         => { "10.10.10.0/24" , "::1" };
 
-        call_collect_interval => "5";
-        }
+  call_collect_interval => "5";
+}
 
-        #########################################################
+#########################################################
 
-        bundle server access_rules()
+bundle server my_access_rules()
+{
+  access:
 
-        {
-        access:
+    policy_server::
 
-          policy_server::
+     "collect_calls"
+         resource_type => "query",
+               admit   => { "10.10.10.10" },
+               comment => "The policy server must admit queries for collect_calls (client initated reporting).";
 
-           "collect_calls"
-               resource_type => "query",
-                     admit   => { "10.10.10.10" };
+    satellite_hosts::
 
-          satellite_hosts::
+      "delta"
+               comment => "Grant access to cfengine hub to collect report deltas",
+         resource_type => "query",
+               admit   => { "policy_hub" };
 
-            "delta"
-                     comment => "Grant access to cfengine hub to collect report deltas",
-               resource_type => "query",
-                     admit   => { "policy_hub" };
-
-            "full"
-                    comment => "Grant access to cfengine hub to collect full report dump",
-              resource_type => "query",
-                    admit   => { "policy_hub"  };
-        }
+      "full"
+              comment => "Grant access to cfengine hub to collect full report dump",
+        resource_type => "query",
+              admit   => { "policy_hub"  };
+}
 ```
+
+**Note:** In the [Masterfiles Policy Framework][Masterfiles Policy Framework], `body server control` and default access rules are found in `controls/cf_serverd.cf`.
 
 **History:** Was introduced in Enterprise 3.0.0 (2012)
 

--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -16,7 +16,7 @@ You layer the access policy by denying all access and then allowing it
 only to selected clients, then denying to an even more restricted set.
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -302,7 +302,7 @@ aforementioned attributes, and it's **not recommended** to use in new
 policy. Example:
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -316,7 +316,7 @@ access:
 The best way to write the same policy would be the following:
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 
@@ -668,7 +668,7 @@ specified hosts. The promiser is an anchored regular expression.
 **Example:**
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 {
 access:
 

--- a/reference/promise-types/roles.markdown
+++ b/reference/promise-types/roles.markdown
@@ -25,7 +25,7 @@ send classes when using `cf-runagent` in order to activate sleeping
 promises. This mechanism limits their ability to do this.
 
 ```cf3
-bundle server access_rules()
+bundle server my_access_rules()
 
 {
 roles:


### PR DESCRIPTION
This change is intended to help clarify the fact that users can (and should)
define their own server bundles instead of modifying the vendored policy and
that bundle server access_rules is not a special name.

Ticket: CFE-3427
Changelog: Title